### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/legnoh/google-pollen-exporter/security/code-scanning/10](https://github.com/legnoh/google-pollen-exporter/security/code-scanning/10)

The best way to fix this problem is to explicitly add a `permissions` block at the appropriate location in the workflow file to restrict the default `GITHUB_TOKEN` permissions to the minimum necessary. Since there is only one job in this workflow (`ci`), and all steps depend on being able to read the repository contents but do not require write access (they do not push code, merge PRs, etc.), we can safely add a top-level `permissions: contents: read` entry just below the `name: CI` line. This will ensure this restriction applies to all jobs in the workflow, and can be easily overridden for individual jobs/steps in the future if required.

**Steps:**
- Insert the `permissions:` block at the workflow root (after the `name:` line and before `on:`).
- Set the block to `contents: read`.
- No additional dependencies, imports, or file modifications are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
